### PR TITLE
Proposal: separate template and config

### DIFF
--- a/src/pyscaffoldext/dsproject/extension.py
+++ b/src/pyscaffoldext/dsproject/extension.py
@@ -70,7 +70,10 @@ def add_dsproject(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
         },
         "environment.yml": (template("environment_yml"), NO_OVERWRITE),
         "models": {".gitignore": gitignore_all},
-        "notebooks": {"template.ipynb": (template("template_ipynb"), NO_OVERWRITE)},
+        "notebooks": {
+            "config.ipynb": (template("config_ipynb"), NO_OVERWRITE),
+            "template.ipynb": (template("template_ipynb"), NO_OVERWRITE),
+        },
         "references": {".gitignore": ("", NO_OVERWRITE)},
         "reports": {"figures": {".gitignore": ("", NO_OVERWRITE)}},
         "scripts": {

--- a/src/pyscaffoldext/dsproject/templates/config_ipynb.template
+++ b/src/pyscaffoldext/dsproject/templates/config_ipynb.template
@@ -1,0 +1,142 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# General configuration for your notebooks\n",
+    "\n",
+    "This file is designed as a place to store configuration that you don't want to keep repeating all over in your notebook files,\n",
+    "such as loading extensions or setting up matplotlib.\n",
+    "\n",
+    "To use it in your files just add the followin a magic comment:\n",
+    "\n",
+    "```ipynb\n",
+    "%run ./config.ipynb\n",
+    "```\n",
+    "\n",
+    "Although the `run` magic directive will make any variable defined in the `config.ipynb` (or module imported) also available in the notebook, please refrain yourself in using these capability...\n",
+    "It is good to make things as explicit as possible and `config.ipynb` should only be used to configure things that usually stay behind the scenes anyway."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load Jupyter extensions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configure Python's logger"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import logging\n",
+    "logging.basicConfig(level=logging.INFO, stream=sys.stdout)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configure `matplotlib` to display nice plots inside the notebook itself"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "%config InlineBackend.figure_format = 'retina'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `seaborn` library can be used to make `matplotlib` graphs look even nicer..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import seaborn\n",
+    "seaborn.set_context(\"poster\")\n",
+    "seaborn.set(rc={\"figure.figsize\": (16, 9.)})\n",
+    "seaborn.set_style(\"whitegrid\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configure `pandas` to display tables nicely"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas\n",
+    "pandas.set_option(\"display.max_rows\", 120)\n",
+    "pandas.set_option(\"display.max_columns\", 120)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.2"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "metadata": {
+     "collapsed": false
+    },
+    "source": []
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/src/pyscaffoldext/dsproject/templates/template_ipynb.template
+++ b/src/pyscaffoldext/dsproject/templates/template_ipynb.template
@@ -6,6 +6,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%run ./config.ipynb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import os\n",
     "import sys\n",
     "import math\n",
@@ -14,28 +23,18 @@
     "\n",
     "import numpy as np\n",
     "import scipy as sp\n",
+    "\n",
     "import sklearn\n",
+    "\n",
     "import statsmodels.api as sm\n",
     "from statsmodels.formula.api import ols\n",
     "\n",
-    "%load_ext autoreload\n",
-    "%autoreload 2\n",
-    "\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline\n",
-    "%config InlineBackend.figure_format = 'retina'\n",
     "\n",
     "import seaborn as sns\n",
-    "sns.set_context(\"poster\")\n",
-    "sns.set(rc={\"figure.figsize\": (16, 9.)})\n",
-    "sns.set_style(\"whitegrid\")\n",
     "\n",
-    "import pandas as pd\n",
-    "pd.set_option(\"display.max_rows\", 120)\n",
-    "pd.set_option(\"display.max_columns\", 120)\n",
-    "\n",
-    "logging.basicConfig(level=logging.INFO, stream=sys.stdout)"
+    "import pandas as pd"
    ]
   },
   {
@@ -78,7 +77,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.1"
   },
   "pycharm": {
    "stem_cell": {
@@ -91,5 +90,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
The existence of a notebook template is a very nice thing, since we can define common blocks of code that we always rely on...

However the current implementation have a huge chunk right in the beginning of the file with all the boilerplate code (e.g. configuring jupyter extensions and the way things are displayed in the notebook).

I wonder if using a single file to centralise all this "boilerplate jupyter configuration" makes sense... The idea is not to replace the template, but rather get unimportant things (like configuring how many columns pandas will display), out of the way.

This way a person can have a single line on top of the file:

```ipynb
%run ./config.ipynb
```

and start writing some text for good'old literal programming, and the readers will not be distracted by the usual chores... (that is what I find myself doing these days: my template is just `%run ./config.ipynb`...)

This approach also allow users to change things in one place (e.g. font size for the graphs) and have it automatically changing in all the notebooks, which can be quite neat.