### PR TITLE
Change to the new way of building in README template

### DIFF
--- a/src/pyscaffoldext/dsproject/templates/readme_md.template
+++ b/src/pyscaffoldext/dsproject/templates/readme_md.template
@@ -81,10 +81,10 @@ Then take a look into the `scripts` and `notebooks` folders.
 ├── reports                 <- Generated analysis as HTML, PDF, LaTeX, etc.
 │   └── figures             <- Generated plots and figures for reports.
 ├── scripts                 <- Analysis and production scripts which import the
-│                              actual PYTHON_PKG, e.g. train_model.
+│                              actual Python package, e.g. train_model.py.
 ├── setup.cfg               <- Declarative configuration of your project.
-├── setup.py                <- Use `python setup.py develop` to install for development or
-|                              or create a distribution with `python setup.py bdist_wheel`.
+├── setup.py                <- Use `pip install -e .` to install for development or
+|                              or create a distribution with `tox -e build`.
 ├── src
 │   └── ${pkg} <- Actual Python package where the main functionality goes.
 ├── tests                   <- Unit tests which can be run with `py.test`.
@@ -97,12 +97,12 @@ Then take a look into the `scripts` and `notebooks` folders.
 
 ## Note
 
-This project has been set up using PyScaffold ${version} and the [dsproject extension] ${dsproject_version}.
-For details and usage information on PyScaffold see https://pyscaffold.org/.
+This project has been set up using [PyScaffold] ${version} and the [dsproject extension] ${dsproject_version}.
 
 [conda]: https://docs.conda.io/
 [pre-commit]: https://pre-commit.com/
 [Jupyter]: https://jupyter.org/
 [nbstripout]: https://github.com/kynan/nbstripout
 [Google style]: http://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings
+[PyScaffold]: https://pyscaffold.org/
 [dsproject extension]: https://github.com/pyscaffold/pyscaffoldext-dsproject

--- a/src/pyscaffoldext/dsproject/templates/readme_md.template
+++ b/src/pyscaffoldext/dsproject/templates/readme_md.template
@@ -77,6 +77,7 @@ Then take a look into the `scripts` and `notebooks` folders.
 ├── notebooks               <- Jupyter notebooks. Naming convention is a number (for
 │                              ordering), the creator's initials and a description,
 │                              e.g. `1.0-fw-initial-data-exploration`.
+├── pyproject.toml          <- Build system configuration. Do not change!
 ├── references              <- Data dictionaries, manuals, and all other materials.
 ├── reports                 <- Generated analysis as HTML, PDF, LaTeX, etc.
 │   └── figures             <- Generated plots and figures for reports.


### PR DESCRIPTION
Some minor changes in the README template reflecting the new ways of building/installing a package since PyScaffold 4.0