### PR TITLE
remove no_skeleton

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -144,6 +144,5 @@ extensions =
     custom_extension
     markdown
     namespace
-    no_skeleton
     pre_commit
 namespace = pyscaffoldext


### PR DESCRIPTION
Would you be OK with this per https://github.com/pyscaffold/pyscaffoldext-dsproject/issues/55? Learning `typer` and adapting files is something I don't have time for rn, but I do notice myself often expecting a `skeleton.py`-like file and corresponding unit tests when I'm creating a new repo with the `dsproj` extension.